### PR TITLE
meson: fix concatenation str to list

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -90,8 +90,10 @@ com_sources = ['src/sov/config/config.c',
 	       'src/modules/zen_core/zc_wrapper.c',
 	       'src/modules/zen_text/text.c']
 
-sov_sources = com_sources + 'src/sov/main.c'
-tst_sources = com_sources + 'src/sov/tree_test.c'
+sov_sources = com_sources
+sov_sources += 'src/sov/main.c'
+tst_sources = com_sources
+tst_sources += 'src/sov/tree_test.c'
 
 sov_dependencies = [xdg_output_unstable_v1, wayland_client, wlr_layer_shell_unstable_v1, xdg_shell, rt, freetype, math]
 

--- a/meson.build
+++ b/meson.build
@@ -90,10 +90,8 @@ com_sources = ['src/sov/config/config.c',
 	       'src/modules/zen_core/zc_wrapper.c',
 	       'src/modules/zen_text/text.c']
 
-sov_sources = com_sources
-sov_sources += 'src/sov/main.c'
-tst_sources = com_sources
-tst_sources += 'src/sov/tree_test.c'
+sov_sources = [com_sources, 'src/sov/main.c']
+tst_sources = [com_sources, 'src/sov/tree_test.c']
 
 sov_dependencies = [xdg_output_unstable_v1, wayland_client, wlr_layer_shell_unstable_v1, xdg_shell, rt, freetype, math]
 


### PR DESCRIPTION
I got an error when I was trying to build an app:
`meson.build:93:0: ERROR: Invalid use of addition: can only concatenate list (not "str") to list`

meson version: 0.59.4
platform: Fedora 35

So, I did a fix and share it with you.