### PR TITLE
Free on buffer

### DIFF
--- a/src/modules/zen_core/zc_cstring.c
+++ b/src/modules/zen_core/zc_cstring.c
@@ -218,8 +218,8 @@ char* cstr_new_file(char* path)
 	{
 	    // Something went wrong, throw away the memory and set
 	    // the buffer to NULL
-	    free(buffer);
 	    buffer = NULL;
+	    free(buffer);
 	}
 
 	// Always remember to close the file.

--- a/src/modules/zen_core/zc_cstring.c
+++ b/src/modules/zen_core/zc_cstring.c
@@ -214,12 +214,15 @@ char* cstr_new_file(char* path)
 	// and buffer is now officially a string
 	buffer[string_size] = '\0';
 
-	if (string_size != read_size)
+	if (read_size != 0) 
 	{
-	    // Something went wrong, throw away the memory and set
-	    // the buffer to NULL
-	    buffer = NULL;
-	    free(buffer);
+		if (string_size != read_size)
+		{
+		    // Something went wrong, throw away the memory and set
+		    // the buffer to NULL
+		    free(buffer);
+		    buffer = NULL;
+		}
 	}
 
 	// Always remember to close the file.


### PR DESCRIPTION
I was getting an invalid pointer on the buffer, this solves it, not the best solution but its one that works

// the error itself
```
swayoverview v0.71 by Milan Toth ( www.milgra.com )
listens on standard input for '0' - hide panel '1' - show panel '2' - quit
free(): invalid pointer
[1]    56526 IOT instruction (core dumped)  sov
```