### PR TITLE
Only use execinfo on glibc - fixes compilation on Alpine Linux v3.17

### DIFF
--- a/src/mt_core/mt_memory.c
+++ b/src/mt_core/mt_memory.c
@@ -37,7 +37,10 @@ void mt_memory_stats();
 
 #if __INCLUDE_LEVEL__ == 0
 
+// Musl-libc doesn't support execinfo, libexecinfo _might_ work.
+#if defined(__GLIBC__)
 #include <execinfo.h>
+#endif
 #include <string.h>
 
 struct mt_memory_head


### PR DESCRIPTION
Musl-libc does not support execinfo.
Since Alpine Linux v3.17, libexecinfo is no longer available and has been deprecated.

For more information, check out:
https://git.alpinelinux.org/aports/commit/?id=50795a14dee639ce2dcc836e2b2baca9bad4a1b1

[libunwind](https://www.nongnu.org/libunwind/index.html) might be a viable alternative if the memory debugging functionality would be needed on musl-libc based systems.