### PR TITLE
Fix long arguments mapping

### DIFF
--- a/src/sov/sov.c
+++ b/src/sov/sov.c
@@ -363,8 +363,8 @@ int main(int argc, char** argv)
 	{"columns", optional_argument, NULL, 'c'},
 	{"anchor", optional_argument, NULL, 'a'},
 	{"margin", optional_argument, NULL, 'm'},
-	{"ratio", optional_argument, NULL, 's'},
-	{"timeout", optional_argument, NULL, 'r'},
+	{"ratio", optional_argument, NULL, 'r'},
+	{"timeout", optional_argument, NULL, 't'},
 	{"holdkey", optional_argument, NULL, 'k'}};
 
     while ((c = getopt_long(argc, argv, "vhno:r:s:a:m:t:c:k:", long_options, &option_index)) != -1)


### PR DESCRIPTION
Due to wrong parsing of long arguments **ratio** and **timeout** were considered **style** and **ratio** respectively, resulting in broken layout with wrong **ratio** (e.g. 200 as **timeout**) or silently ignored invalid path to styles because of [`else`][else] branch checking result of `opendir(cfg_path_loc)`.

[else]: https://github.com/unennhexium/sov/blob/ec2c9a70f69c39edb9a7046aa014eea658d64cff/src/sov/sov.c#L422

After fix arguments parsed according to `usage` printed with `--help`|`-h`.

### Before changes

<details>
<summary>Long arguments</summary>
<pre>
❯ rm -f /tmp/sovpipe && mkfifo /tmp/sovpipe && tail -f /tmp/sovpipe | sov --timeout=200 --holdkey=65515 -v
Sway Overview v0.94 by Milan Toth ( www.milgra.com )
If you like this app try :
- Wayland Control Panel ( github.com/milgra/wcp)
- Visual Music Player (github.com/milgra/vmp)
- Multimedia File Manager (github.com/milgra/mmfm)
- SwayOS (swayos.github.io)
Games :
- Brawl (github.com/milgra/brawl)
- Cortex ( github.com/milgra/cortex )
- Termite (github.com/milgra/termite)

DEBUG  Set log level to DEBUG                                                                        18:25:36:146327 ../src/mt_core/mt_log.c : 172
style path    : /home/user/.config/sov
css path      : /home/user/.config/sov/html/main.css
html path     : /home/user/.config/sov/html/main.html
image path    : /home/user/.config/sov/img
ratio         : 200
anchor        :
margin        : 0
timeout       : 0
columns       : 5
holdkey       : 65515
use_name      : false
DEBUG  xdg output handle logical size, 1920 1080 for monitor 0                                       18:25:36:160907 ../src/kinetic_ui/ku_connector_wayland.c : 1498
^C
</pre>
</details>
<details>
<summary>Short arguments</summary>
<pre>
❯ rm -f /tmp/sovpipe && mkfifo /tmp/sovpipe && tail -f /tmp/sovpipe | sov -t 200 -k 65515 -v
Sway Overview v0.94 by Milan Toth ( www.milgra.com )
If you like this app try :
- Wayland Control Panel ( github.com/milgra/wcp)
- Visual Music Player (github.com/milgra/vmp)
- Multimedia File Manager (github.com/milgra/mmfm)
- SwayOS (swayos.github.io)
Games :
- Brawl (github.com/milgra/brawl)
- Cortex ( github.com/milgra/cortex )
- Termite (github.com/milgra/termite)

DEBUG  Set log level to DEBUG                                                                        18:25:56:933315 ../src/mt_core/mt_log.c : 172
style path    : /home/user/.config/sov
css path      : /home/user/.config/sov/html/main.css
html path     : /home/user/.config/sov/html/main.html
image path    : /home/user/.config/sov/img
ratio         : 8
anchor        :
margin        : 0
timeout       : 200
columns       : 5
holdkey       : 65515
use_name      : false
DEBUG  xdg output handle logical size, 1920 1080 for monitor 0                                       18:25:56:947040 ../src/kinetic_ui/ku_connector_wayland.c : 1498
^C
</pre>
</details>

### After changes (consistent behavior)

<details>
<summary>Long arguments</summary>
<pre>
❯ rm -f /tmp/sovpipe && mkfifo /tmp/sovpipe && tail -f /tmp/sovpipe | sov --timeout=200 --holdkey=65515 -v
Sway Overview v0.94 by Milan Toth ( www.milgra.com )
If you like this app try :
- Wayland Control Panel ( github.com/milgra/wcp)
- Visual Music Player (github.com/milgra/vmp)
- Multimedia File Manager (github.com/milgra/mmfm)
- SwayOS (swayos.github.io)
Games :
- Brawl (github.com/milgra/brawl)
- Cortex ( github.com/milgra/cortex )
- Termite (github.com/milgra/termite)

DEBUG  Set log level to DEBUG                                                                        18:39:36:227201 ../src/mt_core/mt_log.c : 172
style path    : /home/user/.config/sov
css path      : /home/user/.config/sov/html/main.css
html path     : /home/user/.config/sov/html/main.html
image path    : /home/user/.config/sov/img
ratio         : 8
anchor        :
margin        : 0
timeout       : 200
columns       : 5
holdkey       : 65515
use_name      : false
DEBUG  xdg output handle logical size, 1920 1080 for monitor 0                                       18:39:36:240887 ../src/kinetic_ui/ku_connector_wayland.c : 1498
^C
</pre>
</details>
<details>
<summary>Short arguments</summary>
<pre>
❯ rm -f /tmp/sovpipe && mkfifo /tmp/sovpipe && tail -f /tmp/sovpipe | sov -t 200 -k 65515 -v
Sway Overview v0.94 by Milan Toth ( www.milgra.com )
If you like this app try :
- Wayland Control Panel ( github.com/milgra/wcp)
- Visual Music Player (github.com/milgra/vmp)
- Multimedia File Manager (github.com/milgra/mmfm)
- SwayOS (swayos.github.io)
Games :
- Brawl (github.com/milgra/brawl)
- Cortex ( github.com/milgra/cortex )
- Termite (github.com/milgra/termite)

DEBUG  Set log level to DEBUG                                                                        18:39:50:874490 ../src/mt_core/mt_log.c : 172
style path    : /home/user/.config/sov
css path      : /home/user/.config/sov/html/main.css
html path     : /home/user/.config/sov/html/main.html
image path    : /home/user/.config/sov/img
ratio         : 8
anchor        :
margin        : 0
timeout       : 200
columns       : 5
holdkey       : 65515
use_name      : false
DEBUG  xdg output handle logical size, 1920 1080 for monitor 0                                       18:39:50:888786 ../src/kinetic_ui/ku_connector_wayland.c : 1498
^C
</pre>
</details>