### PR TITLE
Improve drawing border w/o radius

### DIFF
--- a/src/kinetic_ui/ku_draw.c
+++ b/src/kinetic_ui/ku_draw.c
@@ -354,36 +354,39 @@ void ku_draw_border(ku_bitmap_t* bitmap, int x, int y, int w, int h, int r, floa
 	    c1); // right bottom
     }
 
+	float e_x = e;
+	float e_y = r > 0 ? e : 0;
+
     ku_draw_rect(
 	bitmap,
 	x,
-	y + e + r,
-	e,
-	h - 2 * e - 2 * r,
+	y + e_y + r,
+	e_x,
+	h - 2 * e_y - 2 * r,
 	c1,
 	0); // left vertical grad
     ku_draw_rect(
 	bitmap,
-	x + w - e,
-	y + e + r,
-	e,
-	h - 2 * e - 2 * r,
+	x + w - e_x,
+	y + e_y + r,
+	e_x,
+	h - 2 * e_y - 2 * r,
 	c1,
 	0); // right vertical grad
     ku_draw_rect(
 	bitmap,
-	x + e + r,
+	x + e_x + r,
 	y,
-	w - 2 * e - 2 * r,
-	e,
+	w - 2 * e_x - 2 * r,
+	e_x,
 	c1,
 	0); // top horizontal grad
     ku_draw_rect(
 	bitmap,
-	x + e + r,
-	y + h - e,
-	w - 2 * e - 2 * r,
-	e,
+	x + e_x + r,
+	y + h - e_x,
+	w - 2 * e_x - 2 * r,
+	e_x,
 	c1,
 	0); // bottom horizontal grad
 }


### PR DESCRIPTION
I don't know if you intended the drawing borders to be exactly the way it is now, but it seemed to me that the lack of corners looked wrong and it seems that it might seem that way to others.

I will certainly agree if the current behavior is implemented intentionally and there seems to be a certain aesthetics in this too. The only reason I'm trying to suggest this fix is ​​because the rest of my desktop environment doesn't have similar empty corners, and this commit proposes "like-others" appearance.

> I'm sorry if this should be committed to `kuid` repo. Maybe submodule approach would be suitable to resolve such issues.

### Changes side-by-side

|    Before   |    After   |
|:-----------:|:----------:|
| ![][before] | ![][after] |

[before]: https://github.com/user-attachments/assets/e1a134ba-7a42-40d3-b8f3-4713aa0d337b
[after]: https://github.com/user-attachments/assets/8f3a7af2-f092-4a31-81df-7adf6b29bb32